### PR TITLE
Handle a null RemoteIPAddress

### DIFF
--- a/SerilogW3cMiddleware.cs
+++ b/SerilogW3cMiddleware.cs
@@ -64,7 +64,7 @@ namespace BrianMed.AspNetCore.SerilogW3cMiddleware
             try {
                 DateTime now = DateTime.Now;
 
-                logProperties.RemoteIpAddress = context.Request.HttpContext.Connection.RemoteIpAddress.ToString();
+                logProperties.RemoteIpAddress = context.Request.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "-";
                 logProperties.AuthUser = context.User.Identity.Name ?? "-";
                 logProperties.Date = $"{now.ToString("dd/MMM/yyyy:HH:MM:ss ")}{now.ToString("zzz").Replace(":", "")}";
                 logProperties.Method = context.Request.Method;


### PR DESCRIPTION
In .net core, if the server has not been configured to use X-Forwarded-For headers (see for example https://stackoverflow.com/questions/35441521/remoteipaddress-is-always-null) then the `connection.RemoteIPAddress` is always null; this leads to an exception when we try and call ToString() on it. 

This change  uses a hyphen as a placeholder if no value is available; 
Arguably we could  use `connection.LocalIpAddress` instead of "-", but this is the simpler option. I don't know if `LocalIPAddress` can ever be null... 